### PR TITLE
Ensure the with_* flags are stored in the default env

### DIFF
--- a/wscript
+++ b/wscript
@@ -50,12 +50,12 @@ def configure(conf):
     conf.recurse('tem')
 
     if not conf.options.no_ateles:
+        conf.all_envs[''].with_ateles = True
         conf.recurse('polynomials')
         conf.recurse('atl')
-        conf.env['with_ateles'] = True
     if not conf.options.no_musubi:
+        conf.all_envs[''].with_musubi = True
         conf.recurse('mus')
-        conf.env['with_musubi'] = True
 
     conf.recurse('bin', 'postconfigure')
 


### PR DESCRIPTION
Fixes #2 

This change ensures that the flags indicating whether to build Musubi and Ateles are set in the default environment. They were stored in some other env and hence in the build phase the building of those was skipped.