### PR TITLE
Fix remain_procWeight update for fractional domain weights

### DIFF
--- a/source/apes.f90
+++ b/source/apes.f90
@@ -96,6 +96,7 @@ program apes
     &                              solverCnt   = solverCnt,          &
     &                              domainObj   = domainObj,          &
     &                              domWeights  = params%domWeights,  &
+    &                              share_dom   = params%share_dom,   &
     &                              globProc    = params%general%proc )
 
   ! load each domain solver configuration files

--- a/source/aps_partition_module.f90
+++ b/source/aps_partition_module.f90
@@ -56,7 +56,7 @@ contains
   !! multiplying with total nProc. Then domain is distributed on each process
   !! based up their weights.
   subroutine aps_compute_partitionWeights(nDomains, glob_nProc, domWeights, &
-    &                                     procWeight)
+    &                                     procWeight, share_dom)
     !--------------------------------------------------------------------------!
     !> number of domains
     integer, intent(in) :: nDomains
@@ -66,14 +66,22 @@ contains
     real(kind=rk), allocatable, intent(out) :: domWeights(:,:)
     !> process weights for each domain
     real(kind=rk), intent(in) :: procWeight(nDomains)
+    !> whether all domains are shared on all processes
+    logical, intent(in) :: share_dom
     !--------------------------------------------------------------------------!
     real(kind = rk), dimension(nDomains) :: remain_procWeight
     real(kind = rk) :: totWeight_proc
+    real(kind = rk), parameter :: weight_eps = 100.0_rk * epsilon(1.0_rk)
     integer :: iDomain, iProc
     !--------------------------------------------------------------------------!
 
     allocate(domWeights(glob_nProc,nDomains))
     domWeights = 0.0_rk
+
+    if (share_dom) then
+      domWeights = 1.0_rk / real(nDomains, kind=rk)
+      return
+    end if
 
     remain_procWeight = procWeight
 
@@ -92,12 +100,10 @@ contains
             & 1.0_rk - totWeight_proc)
           ! compute remaining proc weight of this domain after
           ! assigning some weights on earlier processes
-          if (remain_procWeight(iDomain) > 1.0_rk) then
-            remain_procWeight(iDomain) = remain_procWeight(iDomain) &
-              & - domWeights(iProc, iDomain)
-          else
-            remain_procWeight(iDomain) = 1.0_rk - remain_procWeight(iDomain)
-          end if
+          remain_procWeight(iDomain) = remain_procWeight(iDomain) &
+            &                         - domWeights(iProc, iDomain)
+          if (remain_procWeight(iDomain) < weight_eps) &
+            & remain_procWeight(iDomain) = 0.0_rk
           ! update total weight on iProc
           totWeight_proc = sum(domWeights(iProc,:))
         endif

--- a/source/aps_solver_module.f90
+++ b/source/aps_solver_module.f90
@@ -121,7 +121,7 @@ contains
   !! domain is distributed.
   !! Also create mpi communicator groups for each domain
   subroutine aps_create_domainPartition(solver, solverCnt, domainObj,    &
-    &                                   domWeights, globProc )
+    &                                   domWeights, share_dom, globProc )
     ! -------------------------------------------------------------------------!
     !> allocates apes solvers on this local process
     type(aps_solver_type), intent(out) :: solver
@@ -133,6 +133,8 @@ contains
     !! array size - (nProcs, nDomains)
     !! @todo KM: Check if its required for dynamic load balancing
     real(kind=rk), allocatable :: domWeights(:,:)
+    !> decide whether to distribute all domains on all process
+    logical, intent(in) :: share_dom
     !> apes global communication environment
     type(tem_comm_env_type), intent(in) :: globProc
     ! -------------------------------------------------------------------------!
@@ -149,7 +151,8 @@ contains
       & nDomains       = solver%nDomains_total,          &
       & glob_nProc     = globProc%comm_size,             &
       & domWeights     = domWeights,                     &
-      & procWeight     = domainObj(:)%procWeight         )
+      & procWeight     = domainObj(:)%procWeight,        &
+      & share_dom      = share_dom                       )
 
     ! set domainIDs on all process and local process
     call aps_set_proc_domainIDs(domWeights    = domWeights,            &


### PR DESCRIPTION
## Summary

This PR fixes the update logic of `remain_procWeight` in `aps_partition_module.f90`.

## Problem

In the current implementation (around lines 95–100), if `remain_procWeight(iDomain)` is positive but smaller than 1, it is updated in a way that does not correctly preserve the intended remaining share.

This happens, for example, in cases such as:

- `share_domain` active with more than two domains  
  - e.g. 4 domains, each with `procWeight = 0.25`, the `remain_procWeight` will change to 0.75 after one `iProc` iteration, while the intended fractional should stay unchanged.
- `nProc/proc_frac` cases with fractional residual values  
  - e.g. `remain_procWeight = 32.5`, the value may never reduce to zero.